### PR TITLE
feat: Discord oauth

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const express = require('express');
 const filehound = require('filehound');
 const colors = require('colors/safe');
 const session = require('express-session');
+const discordAuth = require('./middleware/discordAuth').default;
 
 global.sessionMemoryStore = new session.MemoryStore();
 global.sessionMiddleware = session({
@@ -21,7 +22,7 @@ const match = {
     '/summertime': 'memes/summertime.pug',
     '/sort': 'other/visort.pug',
     '/sugo': 'games/sugo.pug',
-} 
+}
 
 const app = express();
 
@@ -30,6 +31,10 @@ app.use(express.static('public', {
     etag: false,
     maxAge: 7 * 24 * 60 * 60 * 1000, // a week seems alright
 }));
+
+// We need this here so it's applied to all routes, even the discord middleware.
+app.use(sessionMiddleware);
+app.use(discordAuth);
 
 for(const [key,file] of Object.entries(match)){
     app.get(key, (req, res) => {

--- a/middleware/discordAuth.js
+++ b/middleware/discordAuth.js
@@ -65,6 +65,8 @@ module.exports.default  = async function (req, res, next) {
                 }
             }
         }
+
+        return req.session.discord.user;
     }
 
     req.discord.logout = async () => {
@@ -210,6 +212,10 @@ module.exports.default  = async function (req, res, next) {
                 return res.redirect(REDIRECT_URI);
             }
         }
+    }
+
+    if (req.session.authenticated && req.session.discord) {
+        await req.discord.refreshUser();
     }
 
     next();

--- a/middleware/discordAuth.js
+++ b/middleware/discordAuth.js
@@ -1,0 +1,216 @@
+const { default: axios, AxiosError } = require('axios');
+const Util = require('util');
+
+const REDIRECT_URI = process.env.REDIRECT_URI || false;
+const REDIRECT_URI_CALLBACK = process.env.REDIRECT_URI_CALLBACK || false;
+const CLIENT_ID = process.env.CLIENT_ID || false;
+const CLIENT_SECRET = process.env.CLIENT_SECRET || false;
+// In seconds
+const REFRESH_INTERVAL = 60 * 3;
+
+/** @type {(req: import('express').Request, res: import('express').Response, next: import('express').NextFunction) => void} */
+module.exports.default  = async function (req, res, next) {
+    if (!REDIRECT_URI || !CLIENT_ID || !CLIENT_SECRET) {
+        // discord oauth disabled
+        console.log('Discord oAuth disabled! Could not find env values for: REDIRECT_URI, REDIRECT_URI_CALLBACK, CLIENT_ID, or CLIENT_SECRET');
+        return next();
+    }
+
+    if (req.session.discord === undefined) {
+        req.session.authenticated = false;
+        req.session.discord = {
+            authenticated: false,
+            user: null,
+            tokenData: null,
+            lastFetch: 0,
+            scopes: []
+        };
+    }
+
+    req.discord = {};
+
+    req.discord.refreshUser = async () => {
+        if (!req.session.authenticated || !req.session.discord) return;
+        let ses = req.session.discord;
+
+        if ((ses.lastFetch + (1000 * REFRESH_INTERVAL)) <= Date.now()) {
+            // perform a refresh of discord data.
+            req.session.discord.lastFetch = Date.now();
+
+            try {
+                const response = await axios.get('https://discord.com/api/users/@me', {
+                    headers: {
+                        authorization: `${ses.tokenData.type} ${ses.tokenData.token}`
+                    }
+                });
+
+                req.session.discord.user = response.data;
+                return response.data;
+            } catch (err) {
+                if (err instanceof AxiosError) {
+                    const response = err.response;
+                    if (response.status !== 429 && (response.status > 404 || response.status < 400)) {
+                        // if there's an error, invalidate the session
+                        req.session.authenticated = false;
+                        req.session.discord = {
+                            authenticated: false,
+                            user: null,
+                            token: null,
+                            tokenData: null,
+                            lastFetch: 0,
+                            scopes: []
+                        };
+                    } else {
+                    }
+                }
+            }
+        }
+    }
+
+    req.discord.logout = async () => {
+        if (!req.session.authenticated || !req.session.discord) return;
+
+        const GRANT_PATH_URI = 'https://discord.com/api/v10/oauth2/token/revoke';
+        const CREDENTIALS = Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`, 'utf-8').toString('base64');
+        const params = new URLSearchParams();
+        params.append('token', req.session.discord.tokenData.token);
+        params.append('refresh_token', req.session.discord.tokenData.refresh);
+        params.append('token_type_hint', 'refresh_token');
+
+        try {
+            const options = {
+                method: 'POST',
+                headers: {
+                    'Authorization': 'Basic ' + CREDENTIALS,
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    'Accept': 'application/json'
+                },
+                data: params.toString(),
+                url: GRANT_PATH_URI.toString()
+            };
+            const response = await axios(options);
+
+            let success = false;
+
+            if (response.status === 200) {
+                success = true;
+            }
+
+            req.session.discord = undefined;
+            req.session.authenticated = false;
+
+            return success;
+        } catch(error) {
+            req.session.discord = undefined;
+            req.session.authenticated = false;
+
+            return false;
+        }
+    }
+
+    req.discord.refresh = async () => {
+        if (!req.session.authenticated || !req.session.discord) return;
+        if (req.session.discord && req.session.discord.tokenData) {
+            if (req.session.discord.tokenData.expiresAt >= (Date.now() - (60 * 60 * 1000))) {
+                // discord is giving us the code.
+                const GRANT_PATH_URI = 'https://discord.com/api/v10/oauth2/token';
+                const params = new URLSearchParams();
+                params.append('grant_type', 'refresh_token');
+                params.append('refresh_token', req.session.discord.tokenData.refresh);
+                params.append('redirect_uri', REDIRECT_URI_CALLBACK);
+                params.append('client_id', CLIENT_ID);
+                params.append('client_secret', CLIENT_SECRET);
+
+                try {
+                    const options = {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded',
+                            'Accept': 'application/json'
+                        },
+                        data: params.toString(),
+                        url: GRANT_PATH_URI.toString()
+                    };
+                    const response = await axios(options);
+
+                    req.session.discord.tokenData = {
+                        token: response.data.access_token,
+                        type: response.data.token_type,
+                        refresh: response.data.refresh_token,
+                        expiresAt: Date.now() + (response.data.expires_in || 0)
+                    };
+
+                    req.session.discord.scopes = response.data.scope.split(' ');
+                    req.session.authenticated = true;
+
+                    await req.discord.refreshUser();
+                    return req.session.discord;
+                } catch (error) {
+                    return error;
+                }
+            }
+        }
+    }
+
+    if (req.path === '/discord/logout') {
+        if (req.session.authenticated && req.session.discord) {
+            await req.discord.logout();
+            return res.redirect('/');
+        } else {
+            return res.redirect('/');
+        }
+    }
+
+    if (req.path === '/discord') {
+        if (req.session.authenticated) {
+            return res.render('error.pug', { req, code: 400, title: "Already Authorizied", error: "Already authenticated with discord!" });
+        }
+        if (req.query.code) {
+            // discord is giving us the code.
+            const GRANT_PATH_URI = 'https://discord.com/api/v10/oauth2/token';
+            const params = new URLSearchParams();
+            params.append('grant_type', 'authorization_code');
+            params.append('code', req.query.code);
+            params.append('redirect_uri', REDIRECT_URI_CALLBACK);
+            params.append('client_id', CLIENT_ID);
+            params.append('client_secret', CLIENT_SECRET);
+
+            try {
+                const options = {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                        'Accept': 'application/json'
+                    },
+                    data: params.toString(),
+                    url: GRANT_PATH_URI.toString()
+                };
+                const response = await axios(options);
+
+                req.session.discord.tokenData = {
+                    token: response.data.access_token,
+                    type: response.data.token_type,
+                    refresh: response.data.refresh_token,
+                    expiresAt: Date.now() + (response.data.expires_in || 0)
+                };
+
+                req.session.authenticated = true;
+                await req.discord.refreshUser();
+                return res.redirect('/admin');
+            } catch (error) {
+                let msg = (error.response.data && error.response.data.error_description)
+                    ? error.response.data.error_description
+                    : error.response.data?.error || "Unknown Error"
+                return res.render('error.pug', { req, error: msg });
+            }
+        } else {
+            // we don't have any valid authorization
+            if (!req.session.authenticated || req.session.discord.tokenData.expiresAt < Date.now()) {
+                // we redirect to discord.
+                return res.redirect(REDIRECT_URI);
+            }
+        }
+    }
+
+    next();
+}

--- a/middleware/discordAuth.js
+++ b/middleware/discordAuth.js
@@ -146,9 +146,9 @@ module.exports.default  = async function (req, res, next) {
                     req.session.authenticated = true;
 
                     await req.discord.refreshUser();
-                    return req.session.discord;
+                    return true;
                 } catch (error) {
-                    return error;
+                    return false;
                 }
             }
         }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { exec } = require('child_process');
 const { appendFile } = require('fs');
+const Util = require('util');
 let fetch = import("node-fetch");
 fetch.then(f => fetch = f);
 
@@ -47,8 +48,11 @@ router.all('/reboot', (req, res) => {
 */
 
 router.get('/login', (req, res) => {
-
-})
+    if (!req.session.authenticated) {
+        res.redirect(discord_redirect_uri);
+    } else {
+    }
+});
 
 router.post('/login', (req, res) => {
     fetch.default('https://discord.com/api/users/@me', {
@@ -73,11 +77,12 @@ router.post('/login', (req, res) => {
 })
 
 router.all("/", (req, res) => {
-    if(!req.session.authenticated) return res.redirect("/login");
+    if(!req.session.authenticated) return res.redirect("/discord");
 
     res.render("admin/main.pug", {
         req,
         res,
+        discord: req.session.discord
     })
 })
 

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -2,7 +2,6 @@ const express = require('express');
 const router = express.Router();
 const { exec } = require('child_process');
 const { appendFile } = require('fs');
-const Util = require('util');
 let fetch = import("node-fetch");
 fetch.then(f => fetch = f);
 
@@ -77,6 +76,8 @@ router.post('/login', (req, res) => {
 })
 
 router.all("/", (req, res) => {
+    // maybe move this to /login?
+    // this will redirect the user to begin authorization with discord.
     if(!req.session.authenticated) return res.redirect("/discord");
 
     res.render("admin/main.pug", {

--- a/views/admin/main.pug
+++ b/views/admin/main.pug
@@ -1,0 +1,4 @@
+include ../includes/style.pug
+h1(style="color: #63f2bd") Login Successful!
+p(style="color: white") Welcome to the admin panel, #{discord.user.username}!
+a(href="/discord/logout", style="color: red") Logout?

--- a/views/error.pug
+++ b/views/error.pug
@@ -1,0 +1,12 @@
+doctype html
+
+include includes/style.pug
+
+html(lang="en")
+    head
+        title Login Failed
+    body
+        h1 #{code || 400} - #{title}
+        p(style="color: red") #{error}
+        a(href="./") How about you go back
+    include includes/footer.pug


### PR DESCRIPTION
Example Env:
```env
REDIRECT_URI = "https://discord.com/api/oauth2/authorize?client_id=1234567890101123&redirect_uri=http%3A%2F%2Flocalhost%3A80%2Fdiscord&response_type=code&scope=identify%20email%20guilds"
CLIENT_SECRET = "client secret given by discord in oauth portal"
CLIENT_ID = "1234567890101123"
REDIRECT_URI_CALLBACK = "http://localhost:80/discord"
```
This PR implements the following methods as well, which are available on any request (req):
```ts
namespace request.discord {
    // Logs the user out of discord.
    // This will also revoke the token
    logout: async () => boolean;
    // Attempts to refresh the token.
    // If we've already recently refreshed the token,
    // your request is ignored and false is returned
    refresh: async () => boolean;
    // Attempts to refresh the discord user.
    // Refresh rate limit is set by discordAuth middleware variable
    // named: REFRESH_INTERVAL
    // will return the discord user object even if the refresh fails
    refreshUser: async () => any;
}
```